### PR TITLE
fix typo in lazy config

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ use {
 - with [lazy.nvim](https://github.com/folke/lazy.nvim)
 
 ```lua
-use {
+{
   'Chaitanyabsprip/present.nvim',
   opts = {
     -- ... your config here


### PR DESCRIPTION
Lazy.nvim doesn't use the keywork `use` as mentioned in the [docs](https://lazy.folke.io/spec/examples)